### PR TITLE
feat: continue typing after getOutput

### DIFF
--- a/.changeset/smooth-lamps-divide.md
+++ b/.changeset/smooth-lamps-divide.md
@@ -1,5 +1,0 @@
----
-"@fake-scope/fake-pkg": patch
----
-
-Update README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+playground.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # CLI Testing Tool
 
-// test
-
 A testing library that allows you to test input and outputs of your CLI command.
 
 *Note: This is WIP but it should be ready enough for most common CLI use-cases I can think of*

--- a/cli-examples/__tests__/select.test.js
+++ b/cli-examples/__tests__/select.test.js
@@ -1,6 +1,10 @@
 const path = require('path');
 const { createCommandInterface } = require('../../lib');
-const { FORWARD_ARROW, THREE_DOTS } = require('../test-utils/icons');
+const {
+  FORWARD_ARROW,
+  THREE_DOTS,
+  SELECT_ICON
+} = require('../test-utils/icons');
 
 test('select', async () => {
   const commandInterface = createCommandInterface('node ./select.js', {
@@ -9,7 +13,8 @@ test('select', async () => {
   });
   const terminalBeforeDownArrow = await commandInterface.getOutput();
   expect(terminalBeforeDownArrow.stringOutput).toMatch(
-    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n❯test 1\ntest 2`
+    // eslint-disable-next-line max-len
+    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n${SELECT_ICON}test 1\ntest 2`
   );
   expect(terminalBeforeDownArrow.stringOutput).toMatch('');
   // move to next item
@@ -17,7 +22,7 @@ test('select', async () => {
   const terminalAfterDownArrow = await commandInterface.getOutput();
   expect(terminalAfterDownArrow.stringOutput).toMatch(
     // eslint-disable-next-line max-len
-    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n❯test 1\n? test:${FORWARD_ARROW} \ntest 1\n❯test 2`
+    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n${SELECT_ICON}test 1\n? test:${FORWARD_ARROW} \ntest 1\n${SELECT_ICON}test 2`
   );
   expect(1).toBe(1);
 });

--- a/cli-examples/__tests__/select.test.js
+++ b/cli-examples/__tests__/select.test.js
@@ -1,11 +1,23 @@
 const path = require('path');
 const { createCommandInterface } = require('../../lib');
+const { FORWARD_ARROW, THREE_DOTS } = require('../test-utils/icons');
 
-test('test 123', async () => {
+test('select', async () => {
   const commandInterface = createCommandInterface('node ./select.js', {
-    cwd: path.join(__dirname, '..')
+    cwd: path.join(__dirname, '..'),
+    typeDelay: 500
   });
-  const terminal = await commandInterface.getOutput();
-  console.log(terminal.stringOutput);
+  const terminalBeforeDownArrow = await commandInterface.getOutput();
+  expect(terminalBeforeDownArrow.stringOutput).toMatch(
+    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n❯test 1\ntest 2`
+  );
+  expect(terminalBeforeDownArrow.stringOutput).toMatch('');
+  // move to next item
+  await commandInterface.keys.arrowDown();
+  const terminalAfterDownArrow = await commandInterface.getOutput();
+  expect(terminalAfterDownArrow.stringOutput).toMatch(
+    // eslint-disable-next-line max-len
+    `? test:${THREE_DOTS} \n? test:${FORWARD_ARROW} \n❯test 1\n? test:${FORWARD_ARROW} \ntest 1\n❯test 2`
+  );
   expect(1).toBe(1);
 });

--- a/cli-examples/__tests__/select.test.js
+++ b/cli-examples/__tests__/select.test.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const { createCommandInterface } = require('../../lib');
+
+test('test 123', async () => {
+  const commandInterface = createCommandInterface('node ./select.js', {
+    cwd: path.join(__dirname, '..')
+  });
+  const terminal = await commandInterface.getOutput();
+  console.log(terminal.stringOutput);
+  expect(1).toBe(1);
+});

--- a/cli-examples/select.js
+++ b/cli-examples/select.js
@@ -1,0 +1,25 @@
+const prompts = require('prompts');
+
+const questions = [
+  {
+    type: 'autocomplete',
+    message: `test: `,
+    name: 'selectedProject',
+    choices: [
+      {
+        title: 'test 1',
+        value: 'test1'
+      },
+      {
+        title: 'test 2',
+        value: 'test2'
+      }
+    ],
+    limit: 10
+  }
+];
+
+(async () => {
+  const { selectedProject } = await prompts(questions);
+  console.log(selectedProject);
+})();

--- a/cli-examples/select.js
+++ b/cli-examples/select.js
@@ -15,7 +15,7 @@ const questions = [
         value: 'test2'
       }
     ],
-    limit: 10
+    limit: 4
   }
 ];
 

--- a/cli-examples/test-utils/icons.js
+++ b/cli-examples/test-utils/icons.js
@@ -4,5 +4,6 @@ const win = process.platform === 'win32';
 module.exports = {
   FORWARD_ARROW: win ? '»' : '›',
   CHECK_MARK: win ? '√' : '✔',
-  THREE_DOTS: win ? '...' : '…'
+  THREE_DOTS: win ? '...' : '…',
+  SELECT_ICON: win ? '>' : '❯'
 };

--- a/lib/cli-testing-tool.js
+++ b/lib/cli-testing-tool.js
@@ -38,36 +38,47 @@ const createCommandInterface = (commandString, userOptions = {}) => {
   const options = { ...defaultOptions, ...userOptions };
 
   const commandArgs = commandString.split(' ');
-  const command = spawn(commandArgs[0], commandArgs.slice(1), {
-    detached: true,
-    stdio: 'pipe',
-    cwd: options.cwd,
-    env: options.env
-  });
 
   let outputs = '';
   let isFinishTypingCalled = false;
+  const inputs = [];
 
-  command.stdout.on('data', (data) => {
-    if (options.logData) {
-      console.log(data.toString());
-    }
-    outputs += data.toString();
-  });
+  const initCommandListeners = () => {
+    outputs = '';
+    isFinishTypingCalled = false;
+    const commandInterface = spawn(commandArgs[0], commandArgs.slice(1), {
+      detached: true,
+      stdio: 'pipe',
+      cwd: options.cwd,
+      env: options.env
+    });
 
-  command.stderr.on('data', (error) => {
-    if (options.logData) {
-      console.error(error.toString());
-    }
-    outputs += error.toString();
-  });
+    commandInterface.stdout.on('data', (data) => {
+      if (options.logData) {
+        console.log(data.toString());
+      }
+      outputs += data.toString();
+    });
 
-  command.on('error', (error) => {
-    throw error;
-  });
+    commandInterface.stderr.on('data', (error) => {
+      if (options.logData) {
+        console.error(error.toString());
+      }
+      outputs += error.toString();
+    });
+
+    commandInterface.on('error', (error) => {
+      throw error;
+    });
+
+    return commandInterface;
+  };
+
+  const command = initCommandListeners();
 
   const type = async (text) => {
     if (isFinishTypingCalled) {
+      console.log(inputs);
       throw new Error(
         // eslint-disable-next-line max-len
         '[cli-testing-tool]: `type` cannot be called after `getOutput` or `finishTyping`'
@@ -75,6 +86,7 @@ const createCommandInterface = (commandString, userOptions = {}) => {
     }
 
     await wait(options.typeDelay);
+    inputs.push(text);
 
     return new Promise((resolve) => {
       command.stdin.write(`${text}`, () => {
@@ -107,6 +119,10 @@ const createCommandInterface = (commandString, userOptions = {}) => {
     isFinishTypingCalled = true;
     command.stdin.end();
   };
+
+  // const reset = () => {
+  //   command = initCommandListeners();
+  // };
 
   return {
     type,

--- a/lib/cli-testing-tool.js
+++ b/lib/cli-testing-tool.js
@@ -74,15 +74,11 @@ const createCommandInterface = (commandString, userOptions = {}) => {
     return commandInterface;
   };
 
-  const command = initCommandListeners();
+  let command = initCommandListeners();
 
   const type = async (text) => {
     if (isFinishTypingCalled) {
-      console.log(inputs);
-      throw new Error(
-        // eslint-disable-next-line max-len
-        '[cli-testing-tool]: `type` cannot be called after `getOutput` or `finishTyping`'
-      );
+      command = initCommandListeners();
     }
 
     await wait(options.typeDelay);

--- a/lib/cli-testing-tool.js
+++ b/lib/cli-testing-tool.js
@@ -41,7 +41,6 @@ const createCommandInterface = (commandString, userOptions = {}) => {
 
   let outputs = '';
   let isFinishTypingCalled = false;
-  const inputs = [];
 
   const initCommandListeners = () => {
     outputs = '';
@@ -82,7 +81,6 @@ const createCommandInterface = (commandString, userOptions = {}) => {
     }
 
     await wait(options.typeDelay);
-    inputs.push(text);
 
     return new Promise((resolve) => {
       command.stdin.write(`${text}`, () => {
@@ -115,10 +113,6 @@ const createCommandInterface = (commandString, userOptions = {}) => {
     isFinishTypingCalled = true;
     command.stdin.end();
   };
-
-  // const reset = () => {
-  //   command = initCommandListeners();
-  // };
 
   return {
     type,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-testing-tool",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-testing-tool",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "node-ansiparser": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-testing-tool",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Currently, when you do `getOutput` the command listener shuts down and you cannot do `type` after that. This change will enable users to keep writing more tests even after the getOutput